### PR TITLE
DF-5: Re-add the dockerized php code

### DIFF
--- a/bin/composer
+++ b/bin/composer
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+TERMINAL_OPTIONS="-i"
+
+if [ -t 0 ]
+then
+  TERMINAL_OPTIONS="${TERMINAL_OPTIONS}t"
+fi
+
+docker run --rm "$TERMINAL_OPTIONS" -v "$PWD:/app" -w /app --volume "$SSH_AUTH_SOCK:/ssh-auth.sock" --volume /etc/passwd:/etc/passwd:ro --volume /etc/group:/etc/group:ro --env SSH_AUTH_SOCK=/ssh-auth.sock --user "$(id -u):$(id -g)" composer "$@"

--- a/bin/php
+++ b/bin/php
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+TERMINAL_OPTIONS="-i"
+
+if [ -t 0 ]
+then
+  TERMINAL_OPTIONS="${TERMINAL_OPTIONS}t"
+fi
+
+docker run --rm "$TERMINAL_OPTIONS" -v "$PWD:/app" -w /app --user "$(id -u):$(id -g)" php:cli-alpine "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,22 +1,5 @@
 #!/usr/bin/env bash
 
-# Set up repositories
-sudo apt install software-properties-common
-sudo add-apt-repository ppa:ondrej/php -y
-
-# Install php
-sudo apt install php8.0 php8.0-curl php8.0-xml -y
-
-# Install composer
-curl -sS https://getcomposer.org/installer -o composer-setup.php
-HASH=$(curl -sS https://composer.github.io/installer.sig)
-HASH_RESULT=$(php -r "if (hash_file('SHA384', 'composer-setup.php') === '$HASH') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;")
-if [ "$HASH_RESULT" != "Installer verified" ];
-then
-    echo "$HASH_RESULT"
-    echo "Composer installer could not be verified! Composer will not be installed.";
-else
-    sudo php composer-setup.php --install-dir=/usr/local/bin --filename=composer
-fi
-
-rm -rf composer-setup.php
+# Pull latest php related images
+docker pull php:cli-alpine
+docker pull composer

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# Uninstall php using apt
-sudo apt remove php8.0 php8.0-curl php8.0-xml -y
-
-# Uninstall composer
-sudo rm /usr/local/bin/composer
+# Remove latest php related images
+docker image rm php:cli-alpine
+docker image rm composer

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# Update php using apt
-sudo apt install php8.0 php8.0-curl php8.0-xml -y
-
-# Update composer using its self-update
-sudo composer self-update
+# Pull latest php related images
+docker pull php:cli-alpine
+docker pull composer


### PR DESCRIPTION
Reverts this package back to the dockerized php version. Also removed the unnecessary 7.4 version.